### PR TITLE
Fix load_transactions() newline bug

### DIFF
--- a/apyori.py
+++ b/apyori.py
@@ -369,8 +369,9 @@ def load_transactions(input_file, **kwargs):
         delimiter -- The delimiter of the transaction.
     """
     delimiter = kwargs.get('delimiter', '\t')
-    for transaction in csv.reader(input_file, delimiter=delimiter):
-        yield transaction if transaction else ['']
+    with open(input_file, newline='') as f:
+        for transaction in csv.reader(f, delimiter=delimiter):
+            yield transaction if transaction else ['']
 
 
 def dump_as_json(record, output_file):


### PR DESCRIPTION
load_transactions() currently iterates through characters in the input_file string. Example of the issue can be found here: https://stackoverflow.com/questions/43348498/using-the-load-transactions-function-in-the-apyori-package-in-python/46651675#46651675 . Explicitly defining newline fixes the issue. Also utilized context management.